### PR TITLE
Tests do not drop created tables

### DIFF
--- a/tests/modification-counts.js
+++ b/tests/modification-counts.js
@@ -1,5 +1,5 @@
 require('../test')("Modification counts", function (conn, t) {
-  t.plan(2)
+  t.plan(3)
 
   conn.query("DROP TABLE modification_count_test", function (err) {})
   conn.query("CREATE TABLE modification_count_test (a int)")
@@ -11,6 +11,10 @@ require('../test')("Modification counts", function (conn, t) {
     conn.query('UPDATE modification_count_test SET a = 3', function (err, res) {
       if (err) throw err
       t.equal(res.rowCount, 1, 'UPDATE query result has correct rowCount')
+      conn.query("DROP TABLE modification_count_test", function (err) {
+        t.error(err);
+      })
     })
   })
+
 })

--- a/tests/query-events.js
+++ b/tests/query-events.js
@@ -39,4 +39,10 @@ require('../test')("Query events", function (conn, t) {
         t.deepEqual(expected, received)
       })
   })
+
+  t.test('cleanup', function(t){
+    conn.query("DROP TABLE streaming_test", function(){
+      t.end()
+    })
+  })
 })


### PR DESCRIPTION
Hi,

It looks like tables created by tests are not removed. This change adds dropping tables at the end of tests.
Hope it is OK :).
