### PR TITLE
Modified last-insert-id test so it supports mssql

### DIFF
--- a/tests/last-insert-id.js
+++ b/tests/last-insert-id.js
@@ -3,6 +3,10 @@ require('../test')("Last insert id", function (conn, t) {
     t.skip("Last insert ID not supported by postgres")
     return t.end()
   }
+  if (conn.adapter.name == 'mssql') {
+    t.skip("Last insert ID not supported by mssql")
+    return t.end()
+  }
   t.plan(2)
 
   conn.query("DROP TABLE last_insert_id_test", function (err) {})


### PR DESCRIPTION
Hi,

We've released our Any-DB adapter for MSSQL (https://github.com/Hypermediaisobar-admin/node-any-db-mssql). It's still not 100% compatible (Query is not an instance of readable stream), but passes almost all tests (except for `pause` and `resume`).

We've modified last-insert-id test, so it handles mssql adapter the same way as postgres adapter, i.e., it
informs that adapter does not support last inert id and skips the test.

It would be great if it could be merged into master branch of any-db-adapter-spec :).
