### PR TITLE
Proposal for named parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,8 @@ Users can check it when building queries, for example:
 var sql = 'SELECT * FROM test WHERE foo = '+adapter.namedParameterPrefix+'param1';
 ```
 
+Only adapters that do support named parameters should provide this property.
+
 ### Adapter.positionalParameterMarker
 
 Read-only string used for positional parameters in SQL queries, e.g., '?'.
@@ -274,6 +276,8 @@ Read-only string used for positional parameters in SQL queries, e.g., '?'.
 ```javascript
 var sql = 'SELECT * FROM test WHERE foo = '+adapter.positionalParameterMarker;
 ```
+
+Only adapters that do support positional parameters should provide this property.
 
 ### Adapter.createConnection
 


### PR DESCRIPTION
Hi,

Here's a proposal to implement support for named parameters.
AFAIK, only PostgreSQL does not support them, but they could be optional.

We already have them in MSSQL adapter, but it probably would be better to have them as a part of specification :).

This also introduces adapter property for positional parameter marker, which should return string that is used as a marker in SQL queries, e.g., '?'. Any-DB supports positional parameters, but does not offer any way for users to know, what character/string is used to put them into SQL query.

BTW Query description does not mark params as optional. Is that intentional?
